### PR TITLE
OS X support

### DIFF
--- a/FractalArt.cabal
+++ b/FractalArt.cabal
@@ -16,8 +16,13 @@ executable FractalArt
   include-dirs:     cbits
   if os(linux)
       extra-libraries:  X11
+  if os(darwin)
+      cc-options:       -fmodules
+      extra-libraries:  objc
+      c-sources:        cbits/wallpaper.m
   other-extensions: ForeignFunctionInterface
-  c-sources:        cbits/wallpaper.c
+  if !os(darwin)
+      c-sources:        cbits/wallpaper.c
   build-depends:    base        >=4.7  && <4.9
                   , random      >=1.0  && <1.2
                   , mwc-random  >=0.13 && <0.14

--- a/cbits/wallpaper.m
+++ b/cbits/wallpaper.m
@@ -1,0 +1,36 @@
+#include <stdlib.h>
+
+@import AppKit;
+
+NSSize getRootWindowSize()
+{
+    @autoreleasepool {
+        NSRect frame = [NSScreen mainScreen].frame;
+        return frame.size;
+    }
+}
+
+int
+get_screen_size_x()
+{
+    return (int)getRootWindowSize().width;
+}
+
+int
+get_screen_size_y()
+{
+    return (int)getRootWindowSize().height;
+}
+
+void
+set_wallpaper(char *str)
+{
+    @autoreleasepool {
+        NSWorkspace *sws = [NSWorkspace sharedWorkspace];
+        NSScreen *screen = [NSScreen mainScreen];
+        NSURL *image = [NSURL fileURLWithPath:[NSString stringWithUTF8String:str]];
+
+        NSDictionary *opts = [sws desktopImageOptionsForScreen:screen];
+        [sws setDesktopImageURL:image forScreen:screen options:opts error:nil];
+    }
+}


### PR DESCRIPTION
Add support for OS X screen dimensions and setting wallpaper.  OS X caches wallpaper URLs, so repeated invocations don't change the image until the dock is killed.
